### PR TITLE
Fix/ gitlab in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,5 +4,5 @@ the documentation is in the folder [docs] [1]
 
 The instructions for the installation are in the file [installation.md] [2]
 
-[1]: https://gitlab.com/Indaym/Back-Indaym/tree/master/docs
-[2]: https://gitlab.com/Indaym/Back-Indaym/blob/master/docs/instalation.md
+[1]: docs/
+[2]: docs/instalation.md


### PR DESCRIPTION
Fix des liens gitlab oubliés dans le Readme

Note :
J'ai rajouté les liens en dynamique pour éviter ce genre de désagréments à l'avenir.