### PR TITLE
Config for multi database

### DIFF
--- a/config/waterlineConfig.js
+++ b/config/waterlineConfig.js
@@ -4,31 +4,14 @@
 
 const PGAdapter = require('waterline-postgresql');
 
-module.exports.DBconfig = {
-  adapters: {
-    'postgres': PGAdapter,
-  },
-
+/*
+ * Default config used for everyone
+ */
+const defaultConfig = {
+  adapters: {},
   connections: {
     postgresdb: {
       adapter: 'postgres',
-      connection: {
-        database: 'bnc4cnogpb2rxwd',
-        host: 'bnc4cnogpb2rxwd-postgresql.services.clever-cloud.com',
-        user: 'uy0rfk0tyaulc9garili',
-        password: 'IdTezRfmU1Onx6NhynUf',
-        port: 5432,
-        ssl: false,
-      },
-      /*
-      connection: {
-        database: 'main',
-        host: 'localhost',
-        user: 'indaym',
-        password: 'indaym',
-        port: '4001',
-        ssl: false,
-      },*/
       pool: {
         min: 2,
         max: 20,
@@ -37,14 +20,53 @@ module.exports.DBconfig = {
   },
 };
 
-/**
-      connection: {
-        database: 'bnc4cnogpb2rxwd',
-        host: 'bnc4cnogpb2rxwd-postgresql.services.clever-cloud.com',
-        user: 'uy0rfk0tyaulc9garili',
-        password: 'IdTezRfmU1Onx6NhynUf',
-        port: 5432,
-        ssl: false,
-      },
-
+/*
+ * Stringify of default config to be parse after
  */
+const defaultConfigStr = JSON.stringify(defaultConfig);
+
+/*
+ * Setup environment 
+ * 
+ * - Parse stringified defaulConfig to create new object
+ * - Set PGAdapter need reference can't be stringified
+ * - Set custom connection
+ */
+function setup(connection) {
+  const env = JSON.parse(defaultConfigStr); // Really dirty but need deep copy, any suggestion ?
+  env.adapters['postgres'] = PGAdapter;
+  env.connections.postgresdb.connection = connection;
+  return env;
+}
+
+/*
+ * Environments
+ */
+
+// Production
+const production = setup({
+  database: 'bnc4cnogpb2rxwd',
+  host: 'bnc4cnogpb2rxwd-postgresql.services.clever-cloud.com',
+  user: 'uy0rfk0tyaulc9garili',
+  password: 'IdTezRfmU1Onx6NhynUf',
+  port: 5432,
+  ssl: false,
+});
+
+// Development / Local docker
+const development = setup({
+  database: 'main',
+  host: 'localhost',
+  user: 'indaym',
+  password: 'indaym',
+  port: 4001,
+  ssl: false,
+});
+
+/*
+ * export of environments
+ */
+module.exports = {
+  production,
+  development,
+};

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   },
   "scripts": {
     "start": "node server.js",
+    "start:dev": "node server.js --config development",
     "dev": "node_modules/.bin/nodemon server.js",
     "ddev": "DEBUG=express:* node_modules/.bin/nodemon server.js",
     "debug": "DEBUG=express:* node server.js",
@@ -33,6 +34,7 @@
   },
   "dependencies": {
     "body-parser": "^1.15.2",
+    "commander": "^2.11.0",
     "cors": "^2.8.1",
     "express": "^4.14.0",
     "jsonwebtoken": "^7.2.1",

--- a/server.js
+++ b/server.js
@@ -1,7 +1,24 @@
 /**
  * Import
  */
-// main import
+
+ // checking arguments
+ const commander = require('commander');
+ const databaseConfig = require('./config/waterlineConfig');
+ 
+ commander
+  .option('-c, --config <env>', 'Choose DB config', (val) => {
+    if (!val || !databaseConfig[val]) {
+      process.emitWarning(`Unkown environment "${val}" set to default "production"`, {
+        code: 'ENVIRONMENT CONFIG',
+      });
+      val = 'production';      
+    }
+    return val;
+  })
+  .parse(process.argv);
+
+ // main import
 const express = require('express');
 const waterline = require('waterline');
 const passport = require('passport');
@@ -17,9 +34,9 @@ const JwtStrategy = require('passport-jwt').Strategy;
 const ExtractJwt = require('passport-jwt').ExtractJwt;
 
 // configuration files
-const DBconfig = require('./config/waterlineConfig').DBconfig;
 const config = require('./config/config');
 const collections = require('./src/models');
+const DBconfig = databaseConfig[commander.config || 'production'];
 
 /**
  * API imports

--- a/yarn.lock
+++ b/yarn.lock
@@ -350,7 +350,7 @@ combined-stream@^1.0.5, combined-stream@~1.0.5:
   dependencies:
     delayed-stream "~1.0.0"
 
-commander@^2.2.0:
+commander@^2.11.0, commander@^2.2.0:
   version "2.11.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.11.0.tgz#157152fd1e7a6c8d98a5b715cf376df928004563"
 


### PR DESCRIPTION
Fix #26 

Implemented :
- Add flag --config to choose which database config to use
- Add script `start:dev` to execute server with flag `--config development`
- Reformat waterlineConfig file to support multi database config
- Default config used is 'production'

Warning :
May cause a reset of database, need more tests to verify if it was only once time.

TODO:

- [x] test if this feature reset the database or not
  - [x] @NicolasDelahaigue 
  - [x] @Djavrell

edit by @djavrell: add the todo list